### PR TITLE
http: allow opting out of interrupt-on-cancel for blocking services

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceInterruptOnCancelTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceInterruptOnCancelTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.grpc.api.DefaultGrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterClient;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
+import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
+import io.servicetalk.http.utils.InterruptBlockingServiceOnCancelHttpServiceFilter;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.time.Duration.ofMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A blocking gRPC route is adapted through the same {@code BlockingHttpService} conversion as a plain HTTP blocking
+ * service, so {@code INTERRUPT_BLOCKING_SERVICE_ON_CANCEL} applies to it when the filter is appended on the
+ * underlying HTTP server builder via {@code GrpcServerBuilder#initializeHttp}. No gRPC-specific plumbing is involved.
+ */
+class GrpcServiceInterruptOnCancelTest {
+
+    private static final TestRequest REQUEST = TestRequest.newBuilder().setName("test").build();
+
+    @ParameterizedTest(name = "{displayName} [{index}] interruptOnCancel={0}")
+    @ValueSource(booleans = {true, false})
+    void blockingRouteRespectsRequestContext(boolean interruptOnCancel) throws Exception {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        CountDownLatch cancelLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+
+        BlockingTesterService service = new BlockingTesterService() {
+            @Override
+            public TestResponse test(final GrpcServiceContext ctx, final TestRequest request) {
+                try {
+                    cancelLatch.await();
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                }
+                if (Thread.interrupted()) {
+                    interrupted.set(true);
+                }
+                doneLatch.countDown();
+                return TestResponse.newBuilder().setMessage(request.getName()).build();
+            }
+        };
+
+        ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .initializeHttp(builder -> builder.appendServiceFilter(
+                        new InterruptBlockingServiceOnCancelHttpServiceFilter(interruptOnCancel)))
+                .listenAndAwait(service);
+        try {
+            try (BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                    .buildBlocking(new ClientFactory())) {
+                GrpcClientMetadata metadata = new DefaultGrpcClientMetadata(ofMillis(200));
+                GrpcStatusException e = assertThrows(GrpcStatusException.class,
+                        () -> client.test(metadata, REQUEST));
+                assertThat(e.status().code(), is(DEADLINE_EXCEEDED));
+            }
+            cancelLatch.countDown();
+
+            assertThat("the service must terminate rather than hang", doneLatch.await(30, SECONDS), is(true));
+            assertThat("a blocking gRPC route must follow the request context",
+                    interrupted.get(), is(interruptOnCancel));
+        } finally {
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractServiceAdapterHolder.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/AbstractServiceAdapterHolder.java
@@ -17,12 +17,27 @@ package io.servicetalk.http.api;
 
 import io.servicetalk.http.api.HttpApiConversions.ServiceAdapterHolder;
 
+import static io.servicetalk.http.api.HttpContextKeys.INTERRUPT_BLOCKING_SERVICE_ON_CANCEL;
+
 abstract class AbstractServiceAdapterHolder implements StreamingHttpService, ServiceAdapterHolder {
 
     private final HttpExecutionStrategy serviceInvocationStrategy;
 
     protected AbstractServiceAdapterHolder(final HttpExecutionStrategy serviceInvocationStrategy) {
         this.serviceInvocationStrategy = serviceInvocationStrategy;
+    }
+
+    /**
+     * Resolves {@link HttpContextKeys#INTERRUPT_BLOCKING_SERVICE_ON_CANCEL}. Must be invoked on the request thread:
+     * the request {@link io.servicetalk.context.api.ContextMap} is not thread-safe and is written to elsewhere on
+     * the response path, so it must not be read from the thread that signals cancellation.
+     *
+     * @param request the request whose context carries the value
+     * @return {@code true} if the service thread should be interrupted on cancellation
+     */
+    static boolean interruptOnCancel(final HttpRequestMetaData request) {
+        final Boolean interrupt = request.context().get(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL);
+        return interrupt == null || interrupt;
     }
 
     @Override

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
@@ -64,12 +65,13 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory responseFactory) {
+        final boolean interruptOnCancel = interruptOnCancel(request);
         return new SubscribableSingle<StreamingHttpResponse>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
                 final ThreadInterruptingCancellable tiCancellable = new ThreadInterruptingCancellable(currentThread());
                 try {
-                    subscriber.onSubscribe(tiCancellable);
+                    subscriber.onSubscribe(interruptOnCancel ? tiCancellable : IGNORE_CANCEL);
                 } catch (Throwable cause) {
                     handleExceptionFromOnSubscribe(subscriber, cause);
                     return;
@@ -108,16 +110,18 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                             if (addTrailers) {
                                 messageBody = messageBody.scanWithMapper(() -> new TrailersMapper(payloadWriter));
                             }
-                            messageBody = messageBody.beforeSubscription(() -> new Subscription() {
-                                @Override
-                                public void request(final long n) {
-                                }
+                            if (interruptOnCancel) {
+                                messageBody = messageBody.beforeSubscription(() -> new Subscription() {
+                                    @Override
+                                    public void request(final long n) {
+                                    }
 
-                                @Override
-                                public void cancel() {
-                                    tiCancellable.cancel();
-                                }
-                            });
+                                    @Override
+                                    public void cancel() {
+                                        tiCancellable.cancel();
+                                    }
+                                });
+                            }
                             result = new DefaultStreamingHttpResponse(metaData.status(), version, headers,
                                     metaData.context0(), ctx.executionContext().bufferAllocator(), messageBody,
                                     forTransportReceive(false, version, headers), ctx.headersFactory(),

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
@@ -15,9 +15,14 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Single.fromCallable;
 import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA_STRATEGY;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
@@ -36,8 +41,14 @@ final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory responseFactory) {
-        return request.toRequest().flatMap(req -> fromCallable(() -> original.handle(
-                ctx, req, ctx.responseFactory()).toStreamingResponse()).shareContextOnSubscribe());
+        final boolean interruptOnCancel = interruptOnCancel(request);
+        return request.toRequest().flatMap(req -> {
+            final Single<StreamingHttpResponse> response = fromCallable(
+                    () -> original.handle(ctx, req, ctx.responseFactory()).toStreamingResponse());
+            return (interruptOnCancel ? response :
+                    response.<StreamingHttpResponse>liftSync(NoopCancellableSubscriber::new))
+                    .shareContextOnSubscribe();
+        });
     }
 
     @Override
@@ -54,5 +65,32 @@ final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
             original.closeGracefully();
             return null;
         });
+    }
+
+    /**
+     * Hides the {@link Cancellable} of {@link Single#fromCallable}, which would otherwise interrupt the service
+     * thread, while preserving that operator's handling of a stale interrupt flag.
+     */
+    private static final class NoopCancellableSubscriber implements Subscriber<StreamingHttpResponse> {
+        private final Subscriber<? super StreamingHttpResponse> delegate;
+
+        NoopCancellableSubscriber(final Subscriber<? super StreamingHttpResponse> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            delegate.onSubscribe(IGNORE_CANCEL);
+        }
+
+        @Override
+        public void onSuccess(@Nullable final StreamingHttpResponse result) {
+            delegate.onSuccess(result);
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            delegate.onError(t);
+        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/HttpContextKeys.java
@@ -94,6 +94,26 @@ public final class HttpContextKeys {
      */
     public static final Key<Long> STREAM_ID = newKey("STREAM_ID", Long.class);
 
+    /**
+     * If present and {@code false}, the thread running a blocking service is never
+     * {@link Thread#interrupt() interrupted} when the response is cancelled, for example because the client
+     * disconnected or a timeout fired. Absent or {@code true} keeps the default behavior of an interrupt.
+     * <p>
+     * Server-side only, and limited to services registered via
+     * {@link HttpServerBuilder#listenBlocking(BlockingHttpService)} or
+     * {@link HttpServerBuilder#listenBlockingStreaming(BlockingStreamingHttpService)}, which includes routers and
+     * gRPC services built on them. The value is read before the service is invoked, so it must be set by a filter
+     * that runs ahead of it.
+     * <p>
+     * With {@code false} a {@link BlockingStreamingHttpService} still observes cancellation cooperatively, because
+     * its payload writer is terminated and the next {@link HttpPayloadWriter#write(Object) write} throws
+     * {@link java.io.IOException}. A {@link BlockingHttpService} has no such signal and always runs to completion.
+     * Set {@code false} only if the service cannot block indefinitely: nothing else will release a thread that waits
+     * on something the cancellation does not release.
+     */
+    public static final Key<Boolean> INTERRUPT_BLOCKING_SERVICE_ON_CANCEL =
+            newKey("INTERRUPT_BLOCKING_SERVICE_ON_CANCEL", Boolean.class);
+
     private HttpContextKeys() {
         // No instances
     }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
@@ -55,6 +55,7 @@ import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
+import static io.servicetalk.http.api.HttpContextKeys.INTERRUPT_BLOCKING_SERVICE_ON_CANCEL;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpHeaderNames.TRAILER;
 import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
@@ -353,6 +354,95 @@ class BlockingStreamingToStreamingServiceTest {
         onErrorLatch.await();
         assertThat(throwableRef.get(), instanceOf(InterruptedException.class));
         serviceTerminationLatch.await();
+    }
+
+    @Test
+    void cancelAfterSendMetaDataNotInterruptedWhenContextDisablesIt() throws Exception {
+        CountDownLatch cancelLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+
+        BlockingStreamingHttpService syncService = (ctx, request, response) -> {
+            HttpPayloadWriter<Buffer> writer = response.sendMetaData();
+            for (int i = 0; i < 5; i++) {
+                try {
+                    Thread.sleep(20);
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                }
+                if (Thread.interrupted()) {
+                    interrupted.set(true);
+                }
+            }
+            try {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii("x"));
+            } catch (IOException e) {
+                throwableRef.set(e);
+            } finally {
+                doneLatch.countDown();
+            }
+        };
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, false);
+        StreamingHttpResponse asyncResponse = asyncService.handle(mockCtx, request, reqRespFactory)
+                .subscribeOn(executorExtension.executor()).toFuture().get();
+        assertMetaData(OK, asyncResponse);
+        toSource(asyncResponse.payloadBody()).subscribe(new Subscriber<Buffer>() {
+            @Override
+            public void onSubscribe(final Subscription s) {
+                s.cancel();
+                cancelLatch.countDown();
+            }
+
+            @Override
+            public void onNext(final Buffer s) {
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+        cancelLatch.await();
+        doneLatch.await();
+
+        assertThat("a context-disabled interrupt must not fire", interrupted.get(), is(false));
+        assertThat("cancelling the payload body must terminate the payload writer so the next write() observes it",
+                throwableRef.get(), instanceOf(IOException.class));
+    }
+
+    @Test
+    void onSubscribeReceivesNonNullNoOpCancellableWhenContextDisablesIt() {
+        AtomicReference<Cancellable> cancellableRef = new AtomicReference<>();
+        BlockingStreamingHttpService syncService = (ctx, request, response) -> response.sendMetaData().close();
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, false);
+
+        toSource(asyncService.handle(mockCtx, request, reqRespFactory))
+                .subscribe(new SingleSource.Subscriber<StreamingHttpResponse>() {
+                    @Override
+                    public void onSubscribe(final Cancellable cancellable) {
+                        cancellableRef.set(cancellable);
+                    }
+
+                    @Override
+                    public void onSuccess(@Nullable final StreamingHttpResponse result) {
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                    }
+                });
+
+        Cancellable cancellable = cancellableRef.get();
+        assertThat(cancellable, is(notNullValue()));
+        cancellable.cancel(); // must not throw
     }
 
     @Test

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingToStreamingServiceTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
+import static io.servicetalk.http.api.HttpContextKeys.INTERRUPT_BLOCKING_SERVICE_ON_CANCEL;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class BlockingToStreamingServiceTest {
+
+    @RegisterExtension
+    static final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor()
+            .setClassLevel(true);
+
+    @Mock
+    private HttpExecutionContext mockExecutionCtx;
+
+    private final StreamingHttpRequestResponseFactory reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
+            DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
+    private HttpServiceContext mockCtx;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(mockExecutionCtx.bufferAllocator()).thenReturn(DEFAULT_ALLOCATOR);
+        mockCtx = new TestHttpServiceContext(DefaultHttpHeadersFactory.INSTANCE, reqRespFactory, mockExecutionCtx);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] interruptOnCancel={0}")
+    @NullSource
+    @ValueSource(booleans = {true, false})
+    void cancelDuringHandle(@Nullable Boolean interruptOnCancel) throws Exception {
+        boolean expectInterrupt = interruptOnCancel == null || interruptOnCancel;
+        CountDownLatch handleLatch = new CountDownLatch(1);
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch cancelLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicReference<Cancellable> cancellableRef = new AtomicReference<>();
+
+        BlockingHttpService syncService = (ctx, request, responseFactory) -> {
+            handleLatch.countDown();
+            try {
+                cancelLatch.await();
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+            if (Thread.interrupted()) {
+                interrupted.set(true);
+            }
+            doneLatch.countDown();
+            return responseFactory.ok();
+        };
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        if (interruptOnCancel != null) {
+            request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, interruptOnCancel);
+        }
+
+        toSource(asyncService.handle(mockCtx, request, reqRespFactory)
+                .afterCancel(cancelObserved::countDown)
+                .subscribeOn(executorExtension.executor()))
+                .subscribe(new NoopSubscriber(cancellableRef));
+        handleLatch.await();
+        Cancellable cancellable = cancellableRef.get();
+        assertThat(cancellable, is(notNullValue()));
+        cancellable.cancel();
+        assertThat("cancellation must reach the adapter before the service thread is released, otherwise a missing "
+                + "interrupt is indistinguishable from a late one", cancelObserved.await(30, SECONDS), is(true));
+        cancelLatch.countDown();
+        assertThat(doneLatch.await(30, SECONDS), is(true));
+
+        assertThat("interrupt-on-cancel must follow the resolved value", interrupted.get(), is(expectInterrupt));
+    }
+
+    @Test
+    void onSubscribeReceivesNonNullCancellableWhenNotInterrupting() {
+        AtomicReference<Cancellable> cancellableRef = new AtomicReference<>();
+        BlockingHttpService syncService = (ctx, request, responseFactory) -> responseFactory.ok();
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, false);
+
+        toSource(asyncService.handle(mockCtx, request, reqRespFactory))
+                .subscribe(new NoopSubscriber(cancellableRef));
+
+        Cancellable cancellable = cancellableRef.get();
+        assertThat(cancellable, is(notNullValue()));
+        cancellable.cancel();
+    }
+
+    @Test
+    void staleInterruptFlagIsClearedWhenNotInterrupting() throws Exception {
+        CountDownLatch onErrorLatch = new CountDownLatch(1);
+        AtomicBoolean interruptedOnError = new AtomicBoolean(true);
+        AtomicReference<Thread> serviceThread = new AtomicReference<>();
+        AtomicReference<Thread> onErrorThread = new AtomicReference<>();
+        BlockingHttpService syncService = (ctx, request, responseFactory) -> {
+            serviceThread.set(Thread.currentThread());
+            Thread.currentThread().interrupt();
+            throw new InterruptedException();
+        };
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, false);
+
+        toSource(asyncService.handle(mockCtx, request, reqRespFactory)
+                .subscribeOn(executorExtension.executor()))
+                .subscribe(new SingleSource.Subscriber<StreamingHttpResponse>() {
+                    @Override
+                    public void onSubscribe(final Cancellable cancellable) {
+                    }
+
+                    @Override
+                    public void onSuccess(@Nullable final StreamingHttpResponse result) {
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                        onErrorThread.set(Thread.currentThread());
+                        interruptedOnError.set(Thread.currentThread().isInterrupted());
+                        onErrorLatch.countDown();
+                    }
+                });
+        assertThat(onErrorLatch.await(30, SECONDS), is(true));
+
+        assertThat("the assertion below is only meaningful on the thread that ran the service",
+                onErrorThread.get(), is(serviceThread.get()));
+        assertThat("an InterruptedException from the service must not leave the flag set on the service thread",
+                interruptedOnError.get(), is(false));
+    }
+
+    private static final class NoopSubscriber implements SingleSource.Subscriber<StreamingHttpResponse> {
+        private final AtomicReference<Cancellable> cancellableRef;
+
+        NoopSubscriber(final AtomicReference<Cancellable> cancellableRef) {
+            this.cancellableRef = cancellableRef;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            cancellableRef.set(cancellable);
+        }
+
+        @Override
+        public void onSuccess(@Nullable final StreamingHttpResponse result) {
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingServiceInterruptOnCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingServiceInterruptOnCancelTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingHttpService;
+import io.servicetalk.http.api.BlockingStreamingHttpService;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.utils.InterruptBlockingServiceOnCancelHttpServiceFilter;
+import io.servicetalk.http.utils.TimeoutHttpServiceFilter;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Verifies {@code INTERRUPT_BLOCKING_SERVICE_ON_CANCEL} against a real server, where the response is cancelled by a
+ * timeout while the service is still running.
+ */
+class BlockingServiceInterruptOnCancelTest {
+
+    private static final Duration TIMEOUT = Duration.ofMillis(200);
+
+    private final CountDownLatch cancelled = new CountDownLatch(1);
+    private final CountDownLatch proceed = new CountDownLatch(1);
+    private final CountDownLatch done = new CountDownLatch(1);
+    private final AtomicBoolean interrupted = new AtomicBoolean();
+
+    @ParameterizedTest(name = "{displayName} [{index}] interruptOnCancel={0}")
+    @ValueSource(booleans = {true, false})
+    void blockingService(boolean interruptOnCancel) throws Exception {
+        BlockingHttpService service = (ctx, request, responseFactory) -> {
+            awaitCancellation();
+            return responseFactory.ok();
+        };
+        assertBehavior(builder -> builder.listenBlockingAndAwait(service), interruptOnCancel);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] interruptOnCancel={0}")
+    @ValueSource(booleans = {true, false})
+    void blockingStreamingService(boolean interruptOnCancel) throws Exception {
+        BlockingStreamingHttpService service = (ctx, request, response) -> {
+            awaitCancellation();
+            try {
+                response.sendMetaData().close();
+            } catch (Exception ignored) {
+                // The exchange is already cancelled; only the interrupt behavior is under test.
+            }
+        };
+        assertBehavior(builder -> builder.listenBlockingStreamingAndAwait(service), interruptOnCancel);
+    }
+
+    private void awaitCancellation() {
+        try {
+            proceed.await();
+        } catch (InterruptedException e) {
+            interrupted.set(true);
+        }
+        if (Thread.interrupted()) {
+            interrupted.set(true);
+        }
+        done.countDown();
+    }
+
+    private void assertBehavior(ServerStarter starter, boolean interruptOnCancel) throws Exception {
+        HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
+                .appendServiceFilter(new TimeoutHttpServiceFilter(TIMEOUT, true))
+                .appendServiceFilter(delegate -> new StreamingHttpServiceFilter(delegate) {
+                    @Override
+                    public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                                final StreamingHttpRequest request,
+                                                                final StreamingHttpResponseFactory responseFactory) {
+                        return delegate().handle(ctx, request, responseFactory).afterCancel(cancelled::countDown);
+                    }
+                })
+                .appendServiceFilter(new InterruptBlockingServiceOnCancelHttpServiceFilter(interruptOnCancel));
+
+        ServerContext serverContext = starter.start(builder);
+        try (BlockingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                .buildBlocking()) {
+            assertThat("the timeout must cancel the response while the service is still running",
+                    client.request(client.get("/")).status(), is(INTERNAL_SERVER_ERROR));
+            assertThat(cancelled.await(30, SECONDS), is(true));
+
+            if (!interruptOnCancel) {
+                proceed.countDown();
+            }
+            assertThat("when an interrupt is expected it must be the only thing that releases the service thread",
+                    done.await(30, SECONDS), is(true));
+
+            assertThat("interrupt-on-cancel must follow the request context",
+                    interrupted.get(), is(interruptOnCancel));
+        } finally {
+            proceed.countDown();
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ServerStarter {
+        ServerContext start(HttpServerBuilder builder) throws Exception;
+    }
+}

--- a/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderInterruptOnCancelTest.java
+++ b/servicetalk-http-router-predicate/src/test/java/io/servicetalk/http/router/predicate/HttpPredicateRouterBuilderInterruptOnCancelTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.router.predicate;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+import io.servicetalk.http.api.BlockingStreamingHttpService;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.TestHttpServiceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.HttpContextKeys.INTERRUPT_BLOCKING_SERVICE_ON_CANCEL;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * The router must pass the request context through to the blocking service it routes to, so that
+ * {@code INTERRUPT_BLOCKING_SERVICE_ON_CANCEL} still applies.
+ */
+@ExtendWith(MockitoExtension.class)
+class HttpPredicateRouterBuilderInterruptOnCancelTest {
+
+    @RegisterExtension
+    static final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor()
+            .setClassLevel(true);
+
+    @Mock
+    private HttpExecutionContext mockExecutionCtx;
+
+    private final StreamingHttpRequestResponseFactory reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
+            DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
+    private HttpServiceContext mockCtx;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(mockExecutionCtx.bufferAllocator()).thenReturn(DEFAULT_ALLOCATOR);
+        mockCtx = new TestHttpServiceContext(DefaultHttpHeadersFactory.INSTANCE, reqRespFactory, mockExecutionCtx);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] interruptOnCancel={0}")
+    @ValueSource(booleans = {true, false})
+    void routedServiceRespectsRequestContext(boolean interruptOnCancel) throws Exception {
+        CountDownLatch handleLatch = new CountDownLatch(1);
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch cancelLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicReference<Cancellable> cancellableRef = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+
+        BlockingStreamingHttpService blockingService = (ctx, request, response) -> {
+            handleLatch.countDown();
+            try {
+                cancelLatch.await();
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+            if (Thread.interrupted()) {
+                interrupted.set(true);
+            }
+            doneLatch.countDown();
+        };
+
+        StreamingHttpService routed = new HttpPredicateRouterBuilder()
+                .whenPathEquals("/")
+                .thenRouteTo(blockingService)
+                .buildStreaming();
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, interruptOnCancel);
+
+        toSource(routed.handle(mockCtx, request, reqRespFactory)
+                .afterCancel(cancelObserved::countDown)
+                .subscribeOn(executorExtension.executor()))
+                .subscribe(new SingleSource.Subscriber<StreamingHttpResponse>() {
+                    @Override
+                    public void onSubscribe(final Cancellable cancellable) {
+                        cancellableRef.set(cancellable);
+                    }
+
+                    @Override
+                    public void onSuccess(@Nullable final StreamingHttpResponse result) {
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                    }
+                });
+        handleLatch.await();
+        Cancellable cancellable = cancellableRef.get();
+        assertThat(cancellable, is(notNullValue()));
+        cancellable.cancel();
+        assertThat("cancellation must reach the adapter before the service thread is released, otherwise a missing "
+                + "interrupt is indistinguishable from a late one", cancelObserved.await(30, SECONDS), is(true));
+        cancelLatch.countDown();
+        assertThat(doneLatch.await(30, SECONDS), is(true));
+
+        assertThat("a routed blocking service must follow the request context",
+                interrupted.get(), is(interruptOnCancel));
+    }
+}

--- a/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/InterruptBlockingServiceOnCancelHttpServiceFilter.java
+++ b/servicetalk-http-utils/src/main/java/io/servicetalk/http/utils/InterruptBlockingServiceOnCancelHttpServiceFilter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.HttpExecutionStrategy;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+
+import static io.servicetalk.http.api.HttpContextKeys.INTERRUPT_BLOCKING_SERVICE_ON_CANCEL;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+
+/**
+ * Sets {@link io.servicetalk.http.api.HttpContextKeys#INTERRUPT_BLOCKING_SERVICE_ON_CANCEL} on every request that
+ * passes through, which controls whether the thread running a blocking service is
+ * {@link Thread#interrupt() interrupted} when the response is cancelled.
+ * <p>
+ * Append ahead of the service it should govern. For gRPC, append it on the underlying HTTP server builder via
+ * {@code GrpcServerBuilder#initializeHttp}.
+ *
+ * @see io.servicetalk.http.api.HttpContextKeys#INTERRUPT_BLOCKING_SERVICE_ON_CANCEL
+ */
+public final class InterruptBlockingServiceOnCancelHttpServiceFilter implements StreamingHttpServiceFilterFactory {
+
+    private final boolean interrupt;
+
+    /**
+     * Create a new instance.
+     *
+     * @param interrupt {@code true} to interrupt the service thread on cancellation, {@code false} to only observe
+     * cancellation cooperatively. See
+     * {@link io.servicetalk.http.api.HttpContextKeys#INTERRUPT_BLOCKING_SERVICE_ON_CANCEL} for the caveats of
+     * {@code false}.
+     */
+    public InterruptBlockingServiceOnCancelHttpServiceFilter(final boolean interrupt) {
+        this.interrupt = interrupt;
+    }
+
+    @Override
+    public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+        return new StreamingHttpServiceFilter(service) {
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        final StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, interrupt);
+                return delegate().handle(ctx, request, responseFactory);
+            }
+        };
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadNone();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{interrupt=" + interrupt + '}';
+    }
+}

--- a/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/InterruptBlockingServiceOnCancelHttpServiceFilterTest.java
+++ b/servicetalk-http-utils/src/test/java/io/servicetalk/http/utils/InterruptBlockingServiceOnCancelHttpServiceFilterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.utils;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.DefaultHttpHeadersFactory;
+import io.servicetalk.http.api.DefaultStreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.HttpExecutionContext;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpRequestResponseFactory;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpService;
+import io.servicetalk.http.api.TestHttpServiceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.http.api.HttpContextKeys.INTERRUPT_BLOCKING_SERVICE_ON_CANCEL;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class InterruptBlockingServiceOnCancelHttpServiceFilterTest {
+
+    @Mock
+    private HttpExecutionContext mockExecutionCtx;
+
+    private final StreamingHttpRequestResponseFactory reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
+            DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
+    private HttpServiceContext mockCtx;
+    private final AtomicReference<Boolean> observed = new AtomicReference<>();
+    private final StreamingHttpService delegate = new StreamingHttpService() {
+        @Override
+        public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                    final StreamingHttpRequest request,
+                                                    final StreamingHttpResponseFactory responseFactory) {
+            observed.set(request.context().get(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL));
+            return Single.succeeded(responseFactory.ok());
+        }
+    };
+
+    @BeforeEach
+    void setup() {
+        lenient().when(mockExecutionCtx.bufferAllocator()).thenReturn(DEFAULT_ALLOCATOR);
+        mockCtx = new TestHttpServiceContext(DefaultHttpHeadersFactory.INSTANCE, reqRespFactory, mockExecutionCtx);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] interrupt={0}")
+    @ValueSource(booleans = {true, false})
+    void setsValueOnRequestContext(boolean interrupt) throws Exception {
+        new InterruptBlockingServiceOnCancelHttpServiceFilter(interrupt).create(delegate)
+                .handle(mockCtx, reqRespFactory.get("/"), reqRespFactory).toFuture().get();
+
+        assertThat(observed.get(), is(interrupt));
+    }
+
+    @Test
+    void overwritesAValueAlreadyOnTheRequest() throws Exception {
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_BLOCKING_SERVICE_ON_CANCEL, true);
+
+        new InterruptBlockingServiceOnCancelHttpServiceFilter(false).create(delegate)
+                .handle(mockCtx, request, reqRespFactory).toFuture().get();
+
+        assertThat(observed.get(), is(false));
+    }
+
+    @Test
+    void doesNotInfluenceOffloading() {
+        assertThat(new InterruptBlockingServiceOnCancelHttpServiceFilter(false).requiredOffloads(),
+                is(offloadNone()));
+    }
+}


### PR DESCRIPTION
#### Motivation

When a response is cancelled, for example because the client disconnected or a timeout fired, ServiceTalk interrupts the thread running a `listenBlocking` or `listenBlockingStreaming` service. There is no way to opt out. Applications whose blocking code cannot tolerate an interrupt, or that use libraries which respond to one by closing shared resources, have no recourse.

#### Modifications

- Add `HttpContextKeys.INTERRUPT_BLOCKING_SERVICE_ON_CANCEL`, a request context key that disables the interrupt when set to `false`.
- Honor it in the blocking and blocking-streaming service adapters.
- Add `InterruptBlockingServiceOnCancelHttpServiceFilter` to `http-utils` for setting it, which also covers routers and gRPC services because they build on the same adapters.

#### Result

Blocking services can opt out of interrupt-on-cancel per request. The default is unchanged, so absent the key the thread is still interrupted.

With the interrupt disabled a blocking-streaming service still observes cancellation cooperatively, because its payload writer is terminated and the next write fails. An aggregated blocking service has no such signal and runs to completion, so the option should only be used by services that cannot block indefinitely.

No API compatibility impact; the context key and the filter are additions.

#### Motivation
<!-- Explain the context around why you're making this change. What is the problem you're trying to solve. -->

#### Modifications
<!-- Describe or list the modifications you've done. -->

#### Result
<!-- Describe the final outcome of this change. Highlight if there is any risk, behavior change, or API change. -->
