### PR TITLE
http: allow opting out of interrupt-on-cancel for blocking services

### DIFF
--- a/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceInterruptOnCancelTest.java
+++ b/servicetalk-grpc-netty/src/test/java/io/servicetalk/grpc/netty/GrpcServiceInterruptOnCancelTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.grpc.netty;
+
+import io.servicetalk.concurrent.BlockingIterator;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.grpc.api.BlockingStreamingGrpcServerResponse;
+import io.servicetalk.grpc.api.DefaultGrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcClientMetadata;
+import io.servicetalk.grpc.api.GrpcPayloadWriter;
+import io.servicetalk.grpc.api.GrpcServiceContext;
+import io.servicetalk.grpc.api.GrpcStatusException;
+import io.servicetalk.grpc.netty.TesterProto.TestRequest;
+import io.servicetalk.grpc.netty.TesterProto.TestResponse;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterClient;
+import io.servicetalk.grpc.netty.TesterProto.Tester.BlockingTesterService;
+import io.servicetalk.grpc.netty.TesterProto.Tester.ClientFactory;
+import io.servicetalk.http.api.DisableInterruptOnCancelHttpServiceFilter;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.servicetalk.grpc.api.GrpcStatusCode.DEADLINE_EXCEEDED;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.time.Duration.ofMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A blocking gRPC route is adapted through the same {@code BlockingHttpService} conversion as a plain HTTP blocking
+ * service, so the filter governs it when appended on the underlying HTTP server builder through
+ * {@code GrpcServerBuilder#initializeHttp}. No gRPC-specific plumbing is involved.
+ */
+class GrpcServiceInterruptOnCancelTest {
+
+    private static final TestRequest REQUEST = TestRequest.newBuilder().setName("test").build();
+    private static final int AWAIT_S = 5;
+    private static final int MAX_MESSAGES = 100;
+    private static final int MESSAGES_AFTER_FAILURE = 2;
+    private static final long MESSAGE_GAP_MILLIS = 10;
+
+    @ParameterizedTest(name = "{displayName} [{index}] disableInterrupt={0}")
+    @ValueSource(booleans = {false, true})
+    void blockingRouteRespectsTheFilter(boolean disableInterrupt) throws Exception {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch cancelLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+
+        BlockingTesterService service = new BlockingTesterService() {
+            @Override
+            public TestResponse test(final GrpcServiceContext ctx, final TestRequest request) {
+                try {
+                    cancelLatch.await();
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                }
+                if (Thread.interrupted()) {
+                    interrupted.set(true);
+                }
+                doneLatch.countDown();
+                return TestResponse.newBuilder().setMessage(request.getName()).build();
+            }
+        };
+
+        ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .initializeHttp(builder -> {
+                    builder.appendServiceFilter(cancelObserver(cancelObserved));
+                    if (disableInterrupt) {
+                        builder.appendServiceFilter(DisableInterruptOnCancelHttpServiceFilter.INSTANCE);
+                    }
+                })
+                .listenAndAwait(service);
+        try {
+            try (BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                    .buildBlocking(new ClientFactory())) {
+                GrpcClientMetadata metadata = new DefaultGrpcClientMetadata(ofMillis(200));
+                GrpcStatusException e = assertThrows(GrpcStatusException.class,
+                        () -> client.test(metadata, REQUEST));
+                assertThat(e.status().code(), is(DEADLINE_EXCEEDED));
+            }
+            // The deadline is enforced client-side, so the server-side cancellation can arrive after the client has
+            // already failed. Wait for it, otherwise releasing the handler here would race the interrupt and the
+            // assertion below would pass even when the interrupt was armed.
+            assertThat("the deadline must cancel the server-side response",
+                    cancelObserved.await(AWAIT_S, SECONDS), is(true));
+            if (disableInterrupt) {
+                cancelLatch.countDown();
+            }
+
+            assertThat("when an interrupt is expected it must be the only thing that releases the service thread",
+                    doneLatch.await(AWAIT_S, SECONDS), is(true));
+            assertThat("a blocking gRPC route must follow the filter setting",
+                    interrupted.get(), is(!disableInterrupt));
+        } finally {
+            cancelLatch.countDown();
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] disableInterrupt={0}")
+    @ValueSource(booleans = {false, true})
+    void blockingStreamingRouteRespectsTheFilter(boolean disableInterrupt) throws Exception {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicReference<Throwable> writeFailure = new AtomicReference<>();
+        CountDownLatch firstResponseSent = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+
+        BlockingTesterService service = new BlockingTesterService() {
+            @Override
+            public void testResponseStream(final GrpcServiceContext ctx, final TestRequest request,
+                                           final BlockingStreamingGrpcServerResponse<TestResponse> response)
+                    throws Exception {
+                GrpcPayloadWriter<TestResponse> writer = response.sendMetaData();
+                try {
+                    writer.write(TestResponse.newBuilder().setMessage("first").build());
+                    writer.flush();
+                    firstResponseSent.countDown();
+                    int messagesAfterFailure = 0;
+                    for (int i = 0; i < MAX_MESSAGES && messagesAfterFailure < MESSAGES_AFTER_FAILURE; i++) {
+                        if (sleepWasInterrupted(MESSAGE_GAP_MILLIS) || Thread.interrupted()) {
+                            interrupted.set(true);
+                        }
+                        try {
+                            writer.write(TestResponse.newBuilder().setMessage("x").build());
+                            writer.flush();
+                        } catch (Exception e) {
+                            // gRPC serializes before writing, so the first failure arrives wrapped in a
+                            // SerializationException rather than as the IOException the HTTP layer throws.
+                            writeFailure.compareAndSet(null, e);
+                        }
+                        if (writeFailure.get() != null) {
+                            messagesAfterFailure++;
+                        }
+                    }
+                    writer.close();
+                } catch (Exception e) {
+                    writeFailure.compareAndSet(null, e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            }
+        };
+
+        ServerContext serverContext = GrpcServers.forAddress(localAddress(0))
+                .initializeHttp(builder -> {
+                    if (disableInterrupt) {
+                        builder.appendServiceFilter(DisableInterruptOnCancelHttpServiceFilter.INSTANCE);
+                    }
+                })
+                .listenAndAwait(service);
+        try {
+            try (BlockingTesterClient client = GrpcClients.forAddress(serverHostAndPort(serverContext))
+                    .buildBlocking(new ClientFactory())) {
+                BlockingIterator<TestResponse> iterator = client.testResponseStream(REQUEST).iterator();
+                assertThat("the route never produced its first response", iterator.hasNext(), is(true));
+                iterator.next();
+                // The client gives up on the rest of the stream, which cancels the server-side response body.
+                iterator.close();
+            }
+
+            assertThat("the route must finish regardless of the client having abandoned the stream",
+                    doneLatch.await(AWAIT_S, SECONDS), is(true));
+            assertThat("a write against the abandoned stream must fail whatever the filter decides",
+                    writeFailure.get(), is(notNullValue()));
+            assertThat("the failure must report the terminated payload writer, not something else",
+                    hasIoExceptionCause(writeFailure.get()), is(true));
+            assertThat("a blocking-streaming gRPC route must follow the filter setting",
+                    interrupted.get(), is(!disableInterrupt));
+        } finally {
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+
+    private static boolean hasIoExceptionCause(final Throwable t) {
+        for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+            if (cause instanceof IOException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean sleepWasInterrupted(final long millis) {
+        try {
+            Thread.sleep(millis);
+            return false;
+        } catch (InterruptedException e) {
+            return true;
+        }
+    }
+
+    private static StreamingHttpServiceFilterFactory cancelObserver(final CountDownLatch cancelObserved) {
+        return delegate -> new StreamingHttpServiceFilter(delegate) {
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        final StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                return delegate().handle(ctx, request, responseFactory).afterCancel(cancelObserved::countDown);
+            }
+        };
+    }
+}

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -31,12 +31,14 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Processors.newCompletableProcessor;
 import static io.servicetalk.concurrent.api.SourceAdapters.fromSource;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.handleExceptionFromOnSubscribe;
 import static io.servicetalk.concurrent.internal.SubscriberUtils.safeOnError;
 import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_META_STRATEGY;
 import static io.servicetalk.http.api.DefaultPayloadInfo.forTransportReceive;
+import static io.servicetalk.http.api.DisableInterruptOnCancelHttpServiceFilter.interruptOnCancel;
 import static io.servicetalk.http.api.HeaderUtils.hasContentLength;
 import static io.servicetalk.http.api.HeaderUtils.isTransferEncodingChunked;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
@@ -64,12 +66,13 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory responseFactory) {
+        final boolean interruptOnCancel = interruptOnCancel(request);
         return new SubscribableSingle<StreamingHttpResponse>() {
             @Override
             protected void handleSubscribe(final Subscriber<? super StreamingHttpResponse> subscriber) {
                 final ThreadInterruptingCancellable tiCancellable = new ThreadInterruptingCancellable(currentThread());
                 try {
-                    subscriber.onSubscribe(tiCancellable);
+                    subscriber.onSubscribe(interruptOnCancel ? tiCancellable : IGNORE_CANCEL);
                 } catch (Throwable cause) {
                     handleExceptionFromOnSubscribe(subscriber, cause);
                     return;
@@ -108,16 +111,18 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                             if (addTrailers) {
                                 messageBody = messageBody.scanWithMapper(() -> new TrailersMapper(payloadWriter));
                             }
-                            messageBody = messageBody.beforeSubscription(() -> new Subscription() {
-                                @Override
-                                public void request(final long n) {
-                                }
+                            if (interruptOnCancel) {
+                                messageBody = messageBody.beforeSubscription(() -> new Subscription() {
+                                    @Override
+                                    public void request(final long n) {
+                                    }
 
-                                @Override
-                                public void cancel() {
-                                    tiCancellable.cancel();
-                                }
-                            });
+                                    @Override
+                                    public void cancel() {
+                                        tiCancellable.cancel();
+                                    }
+                                });
+                            }
                             result = new DefaultStreamingHttpResponse(metaData.status(), version, headers,
                                     metaData.context0(), ctx.executionContext().bufferAllocator(), messageBody,
                                     forTransportReceive(false, version, headers), ctx.headersFactory(),

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingToStreamingService.java
@@ -15,11 +15,17 @@
  */
 package io.servicetalk.http.api;
 
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource.Subscriber;
 import io.servicetalk.concurrent.api.Completable;
 import io.servicetalk.concurrent.api.Single;
 
+import javax.annotation.Nullable;
+
+import static io.servicetalk.concurrent.Cancellable.IGNORE_CANCEL;
 import static io.servicetalk.concurrent.api.Single.fromCallable;
 import static io.servicetalk.http.api.DefaultHttpExecutionStrategy.OFFLOAD_RECEIVE_DATA_STRATEGY;
+import static io.servicetalk.http.api.DisableInterruptOnCancelHttpServiceFilter.interruptOnCancel;
 import static io.servicetalk.http.api.HttpExecutionStrategies.defaultStrategy;
 import static java.util.Objects.requireNonNull;
 
@@ -36,8 +42,15 @@ final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
     public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
                                                 final StreamingHttpRequest request,
                                                 final StreamingHttpResponseFactory responseFactory) {
-        return request.toRequest().flatMap(req -> fromCallable(() -> original.handle(
-                ctx, req, ctx.responseFactory()).toStreamingResponse()).shareContextOnSubscribe());
+        final boolean interruptOnCancel = interruptOnCancel(request);
+        return request.toRequest().flatMap(req -> {
+            Single<StreamingHttpResponse> response = fromCallable(
+                    () -> original.handle(ctx, req, ctx.responseFactory()).toStreamingResponse());
+            if (!interruptOnCancel) {
+                response = response.<StreamingHttpResponse>liftSync(IgnoreCancellationSubscriber::new);
+            }
+            return response.shareContextOnSubscribe();
+        });
     }
 
     @Override
@@ -54,5 +67,32 @@ final class BlockingToStreamingService extends AbstractServiceAdapterHolder {
             original.closeGracefully();
             return null;
         });
+    }
+
+    /**
+     * Hides the {@link Cancellable} of {@code Single.fromCallable}, which would otherwise interrupt the service
+     * thread.
+     */
+    private static final class IgnoreCancellationSubscriber implements Subscriber<StreamingHttpResponse> {
+        private final Subscriber<? super StreamingHttpResponse> delegate;
+
+        IgnoreCancellationSubscriber(final Subscriber<? super StreamingHttpResponse> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            delegate.onSubscribe(IGNORE_CANCEL);
+        }
+
+        @Override
+        public void onSuccess(@Nullable final StreamingHttpResponse result) {
+            delegate.onSuccess(result);
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            delegate.onError(t);
+        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DisableInterruptOnCancelHttpServiceFilter.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/DisableInterruptOnCancelHttpServiceFilter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.context.api.ContextMap.Key;
+
+import static io.servicetalk.context.api.ContextMap.Key.newKey;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static java.lang.Boolean.FALSE;
+
+/**
+ * Stops the thread running a blocking service from being {@link Thread#interrupt() interrupted} when the response is
+ * cancelled. Without this filter the thread is interrupted.
+ * <p>
+ * Applies to {@link HttpServerBuilder#listenBlocking(BlockingHttpService)} and
+ * {@link HttpServerBuilder#listenBlockingStreaming(BlockingStreamingHttpService)}, including routers and gRPC
+ * services built on the same adapters. Append it ahead of the service it governs.
+ * <p>
+ * Cancellation is still observable by a {@link BlockingStreamingHttpService}, because its payload writer is
+ * terminated and the next {@link HttpPayloadWriter#write(Object) write} throws {@link java.io.IOException}. A
+ * {@link BlockingHttpService} has no such signal and runs to completion, so nothing releases a thread that blocks
+ * indefinitely.
+ */
+public final class DisableInterruptOnCancelHttpServiceFilter implements StreamingHttpServiceFilterFactory {
+
+    /**
+     * Instance of {@link DisableInterruptOnCancelHttpServiceFilter}.
+     */
+    public static final StreamingHttpServiceFilterFactory INSTANCE = new DisableInterruptOnCancelHttpServiceFilter();
+
+    static final Key<Boolean> INTERRUPT_ON_CANCEL = newKey("INTERRUPT_ON_CANCEL", Boolean.class);
+
+    private DisableInterruptOnCancelHttpServiceFilter() {
+        // Singleton
+    }
+
+    @Override
+    public StreamingHttpServiceFilter create(final StreamingHttpService service) {
+        return new StreamingHttpServiceFilter(service) {
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        final StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                request.context().put(INTERRUPT_ON_CANCEL, FALSE);
+                return delegate().handle(ctx, request, responseFactory);
+            }
+        };
+    }
+
+    @Override
+    public HttpExecutionStrategy requiredOffloads() {
+        return offloadNone();
+    }
+
+    /**
+     * Resolves the value for a request. Must be invoked on the request thread, because the request context is not
+     * thread-safe and is written to elsewhere on the response path.
+     *
+     * @param request the request whose context carries the value
+     * @return {@code true} if the service thread should be interrupted on cancellation
+     */
+    static boolean interruptOnCancel(final HttpRequestMetaData request) {
+        final Boolean interrupt = request.context().get(INTERRUPT_ON_CANCEL);
+        return interrupt == null || interrupt;
+    }
+}

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
@@ -54,6 +54,7 @@ import static io.servicetalk.concurrent.api.Publisher.failed;
 import static io.servicetalk.concurrent.api.Publisher.from;
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static io.servicetalk.http.api.DisableInterruptOnCancelHttpServiceFilter.INTERRUPT_ON_CANCEL;
 import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
 import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
 import static io.servicetalk.http.api.HttpHeaderNames.TRAILER;
@@ -63,6 +64,7 @@ import static io.servicetalk.http.api.HttpResponseStatus.OK;
 import static io.servicetalk.http.api.HttpSerializers.appSerializerUtf8FixLen;
 import static io.servicetalk.utils.internal.ThrowableUtils.throwException;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -353,6 +355,136 @@ class BlockingStreamingToStreamingServiceTest {
         onErrorLatch.await();
         assertThat(throwableRef.get(), instanceOf(InterruptedException.class));
         serviceTerminationLatch.await();
+    }
+
+    @Test
+    void cancelAfterSendMetaDataNotInterruptedWhenDisabled() throws Exception {
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch releaseLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+
+        BlockingStreamingHttpService syncService = (ctx, request, response) -> {
+            HttpPayloadWriter<Buffer> writer = response.sendMetaData();
+            try {
+                releaseLatch.await();
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+            if (Thread.interrupted()) {
+                interrupted.set(true);
+            }
+            try {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii("x"));
+            } catch (IOException e) {
+                throwableRef.set(e);
+            } finally {
+                doneLatch.countDown();
+            }
+        };
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_ON_CANCEL, false);
+        StreamingHttpResponse asyncResponse = asyncService.handle(mockCtx, request, reqRespFactory)
+                .subscribeOn(executorExtension.executor()).toFuture().get();
+        assertMetaData(OK, asyncResponse);
+        toSource(asyncResponse.payloadBody().afterCancel(cancelObserved::countDown))
+                .subscribe(new Subscriber<Buffer>() {
+                    @Override
+                    public void onSubscribe(final Subscription s) {
+                        s.cancel();
+                    }
+
+                    @Override
+                    public void onNext(final Buffer s) {
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                    }
+
+                    @Override
+                    public void onComplete() {
+                    }
+                });
+        assertThat("cancellation must reach the adapter before the service thread is released, otherwise a missing "
+                + "interrupt is indistinguishable from a late one", cancelObserved.await(30, SECONDS), is(true));
+        releaseLatch.countDown();
+        assertThat(doneLatch.await(30, SECONDS), is(true));
+
+        assertThat("a disabled interrupt must not fire", interrupted.get(), is(false));
+        assertThat("cancelling the payload body must still terminate the payload writer, so the next write() "
+                + "observes the cancellation", throwableRef.get(), instanceOf(IOException.class));
+    }
+
+    @Test
+    void cancelBeforeSendMetaDataNotInterruptedWhenDisabled() throws Exception {
+        CountDownLatch handleLatch = new CountDownLatch(1);
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch releaseLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+        AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+
+        BlockingStreamingHttpService syncService = (ctx, request, response) -> {
+            handleLatch.countDown();
+            try {
+                releaseLatch.await();
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+            if (Thread.interrupted()) {
+                interrupted.set(true);
+            }
+            HttpPayloadWriter<Buffer> writer = response.sendMetaData();
+            try {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii("x"));
+            } catch (IOException e) {
+                throwableRef.set(e);
+            } finally {
+                doneLatch.countDown();
+            }
+        };
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_ON_CANCEL, false);
+        toSource(asyncService.handle(mockCtx, request, reqRespFactory)
+                .afterCancel(cancelObserved::countDown)
+                .flatMapPublisher(StreamingHttpResponse::messageBody)
+                .subscribeOn(executorExtension.executor()))
+                .subscribe(new Subscriber<Object>() {
+                    @Override
+                    public void onSubscribe(final Subscription s) {
+                        subscriptionRef.set(s);
+                    }
+
+                    @Override
+                    public void onNext(final Object o) {
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                    }
+
+                    @Override
+                    public void onComplete() {
+                    }
+                });
+        handleLatch.await();
+        Subscription subscription = subscriptionRef.get();
+        assertThat(subscription, is(notNullValue()));
+        subscription.cancel();
+        assertThat("cancellation must reach the adapter before the service thread is released, otherwise a missing "
+                + "interrupt is indistinguishable from a late one", cancelObserved.await(30, SECONDS), is(true));
+        releaseLatch.countDown();
+        assertThat(doneLatch.await(30, SECONDS), is(true));
+
+        assertThat("a disabled interrupt must not fire", interrupted.get(), is(false));
+        assertThat("a cancel delivered before sendMetaData() must still terminate the payload writer, otherwise the "
+                + "service parks in write() forever and never releases its offload thread",
+                throwableRef.get(), instanceOf(IOException.class));
     }
 
     @Test

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingToStreamingServiceTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.api;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.SingleSource;
+import io.servicetalk.concurrent.api.Executor;
+import io.servicetalk.concurrent.api.ExecutorExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static io.servicetalk.buffer.netty.BufferAllocators.DEFAULT_ALLOCATOR;
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.http.api.DisableInterruptOnCancelHttpServiceFilter.INTERRUPT_ON_CANCEL;
+import static io.servicetalk.http.api.HttpApiConversions.toStreamingHttpService;
+import static io.servicetalk.http.api.HttpExecutionStrategies.offloadNone;
+import static io.servicetalk.http.api.HttpProtocolVersion.HTTP_1_1;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class BlockingToStreamingServiceTest {
+
+    @RegisterExtension
+    static final ExecutorExtension<Executor> executorExtension = ExecutorExtension.withCachedExecutor()
+            .setClassLevel(true);
+
+    @Mock
+    private HttpExecutionContext mockExecutionCtx;
+
+    private final StreamingHttpRequestResponseFactory reqRespFactory = new DefaultStreamingHttpRequestResponseFactory(
+            DEFAULT_ALLOCATOR, DefaultHttpHeadersFactory.INSTANCE, HTTP_1_1);
+    private HttpServiceContext mockCtx;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(mockExecutionCtx.bufferAllocator()).thenReturn(DEFAULT_ALLOCATOR);
+        mockCtx = new TestHttpServiceContext(DefaultHttpHeadersFactory.INSTANCE, reqRespFactory, mockExecutionCtx);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] interruptOnCancel={0}")
+    @NullSource
+    @ValueSource(booleans = {true, false})
+    void cancelDuringHandle(@Nullable Boolean interruptOnCancel) throws Exception {
+        boolean expectInterrupt = interruptOnCancel == null || interruptOnCancel;
+        CountDownLatch handleLatch = new CountDownLatch(1);
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch cancelLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicReference<Cancellable> cancellableRef = new AtomicReference<>();
+
+        BlockingHttpService syncService = (ctx, request, responseFactory) -> {
+            handleLatch.countDown();
+            try {
+                cancelLatch.await();
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+            if (Thread.interrupted()) {
+                interrupted.set(true);
+            }
+            doneLatch.countDown();
+            return responseFactory.ok();
+        };
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        if (interruptOnCancel != null) {
+            request.context().put(INTERRUPT_ON_CANCEL, interruptOnCancel);
+        }
+
+        toSource(asyncService.handle(mockCtx, request, reqRespFactory)
+                .afterCancel(cancelObserved::countDown)
+                .subscribeOn(executorExtension.executor()))
+                .subscribe(new NoopSubscriber(cancellableRef));
+        handleLatch.await();
+        Cancellable cancellable = cancellableRef.get();
+        assertThat(cancellable, is(notNullValue()));
+        cancellable.cancel();
+        assertThat("cancellation must reach the adapter before the service thread is released, otherwise a missing "
+                + "interrupt is indistinguishable from a late one", cancelObserved.await(30, SECONDS), is(true));
+        cancelLatch.countDown();
+        assertThat(doneLatch.await(30, SECONDS), is(true));
+
+        assertThat("interrupt-on-cancel must follow the resolved value", interrupted.get(), is(expectInterrupt));
+    }
+
+    @Test
+    void staleInterruptFlagIsClearedWhenNotInterrupting() throws Exception {
+        CountDownLatch onErrorLatch = new CountDownLatch(1);
+        AtomicBoolean interruptedOnError = new AtomicBoolean(true);
+        AtomicReference<Thread> serviceThread = new AtomicReference<>();
+        AtomicReference<Thread> onErrorThread = new AtomicReference<>();
+        BlockingHttpService syncService = (ctx, request, responseFactory) -> {
+            serviceThread.set(Thread.currentThread());
+            Thread.currentThread().interrupt();
+            throw new InterruptedException();
+        };
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+        StreamingHttpRequest request = reqRespFactory.get("/");
+        request.context().put(INTERRUPT_ON_CANCEL, false);
+
+        toSource(asyncService.handle(mockCtx, request, reqRespFactory)
+                .subscribeOn(executorExtension.executor()))
+                .subscribe(new SingleSource.Subscriber<StreamingHttpResponse>() {
+                    @Override
+                    public void onSubscribe(final Cancellable cancellable) {
+                    }
+
+                    @Override
+                    public void onSuccess(@Nullable final StreamingHttpResponse result) {
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                        onErrorThread.set(Thread.currentThread());
+                        interruptedOnError.set(Thread.currentThread().isInterrupted());
+                        onErrorLatch.countDown();
+                    }
+                });
+        assertThat(onErrorLatch.await(30, SECONDS), is(true));
+
+        assertThat("the assertion below is only meaningful on the thread that ran the service",
+                onErrorThread.get(), is(serviceThread.get()));
+        assertThat("an InterruptedException from the service must not leave the flag set on the service thread",
+                interruptedOnError.get(), is(false));
+    }
+
+    private static final class NoopSubscriber implements SingleSource.Subscriber<StreamingHttpResponse> {
+        private final AtomicReference<Cancellable> cancellableRef;
+
+        NoopSubscriber(final AtomicReference<Cancellable> cancellableRef) {
+            this.cancellableRef = cancellableRef;
+        }
+
+        @Override
+        public void onSubscribe(final Cancellable cancellable) {
+            cancellableRef.set(cancellable);
+        }
+
+        @Override
+        public void onSuccess(@Nullable final StreamingHttpResponse result) {
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+        }
+    }
+}

--- a/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingServiceInterruptOnCancelTest.java
+++ b/servicetalk-http-netty/src/test/java/io/servicetalk/http/netty/BlockingServiceInterruptOnCancelTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.http.netty;
+
+import io.servicetalk.buffer.api.Buffer;
+import io.servicetalk.concurrent.api.Single;
+import io.servicetalk.http.api.BlockingHttpClient;
+import io.servicetalk.http.api.BlockingHttpService;
+import io.servicetalk.http.api.BlockingStreamingHttpService;
+import io.servicetalk.http.api.DisableInterruptOnCancelHttpServiceFilter;
+import io.servicetalk.http.api.HttpPayloadWriter;
+import io.servicetalk.http.api.HttpServerBuilder;
+import io.servicetalk.http.api.HttpServiceContext;
+import io.servicetalk.http.api.StreamingHttpRequest;
+import io.servicetalk.http.api.StreamingHttpResponse;
+import io.servicetalk.http.api.StreamingHttpResponseFactory;
+import io.servicetalk.http.api.StreamingHttpServiceFilter;
+import io.servicetalk.http.api.StreamingHttpServiceFilterFactory;
+import io.servicetalk.http.utils.TimeoutHttpServiceFilter;
+import io.servicetalk.transport.api.ServerContext;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.servicetalk.http.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.servicetalk.transport.netty.internal.AddressUtils.localAddress;
+import static io.servicetalk.transport.netty.internal.AddressUtils.serverHostAndPort;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * End-to-end coverage of {@link DisableInterruptOnCancelHttpServiceFilter} over a real client and server. The filter
+ * decides only whether the handler thread is interrupted; everything else about the exchange is unchanged.
+ * <p>
+ * Each cancellation trigger needs a model that it actually reaches. A mid-stream client disconnect and a non-graceful
+ * server close both cancel a {@link BlockingStreamingHttpService}, because the server is already writing. An
+ * aggregated {@link BlockingHttpService} has written nothing yet, so neither transport event reaches it; a
+ * server-side timeout is what cancels an aggregated handler in flight.
+ */
+class BlockingServiceInterruptOnCancelTest {
+
+    private static final String RAW_REQUEST = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    private static final Duration TIMEOUT = Duration.ofMillis(50);
+    // Latch waits cost nothing when they fire; this bound only applies when something is broken.
+    private static final int AWAIT_S = 5;
+    private static final int MAX_CHUNKS = 100;
+    private static final int CHUNKS_AFTER_FAILURE = 2;
+    private static final long CHUNK_GAP_MILLIS = 10;
+
+    @ParameterizedTest(name = "{displayName} [{index}] disableInterrupt={0}")
+    @ValueSource(booleans = {false, true})
+    void timeoutDuringAggregatedService(boolean disableInterrupt) throws Exception {
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch handlerFinished = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+
+        BlockingHttpService service = (ctx, request, responseFactory) -> {
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+            if (Thread.interrupted()) {
+                interrupted.set(true);
+            }
+            handlerFinished.countDown();
+            return responseFactory.ok();
+        };
+
+        HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
+                .appendServiceFilter(new TimeoutHttpServiceFilter(TIMEOUT, true))
+                .appendServiceFilter(cancelObserver(cancelObserved));
+        if (disableInterrupt) {
+            builder.appendServiceFilter(DisableInterruptOnCancelHttpServiceFilter.INSTANCE);
+        }
+        ServerContext serverContext = builder.listenBlockingAndAwait(service);
+        try (BlockingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                .buildBlocking()) {
+            assertThat("the timeout must fire while the handler is still running",
+                    client.request(client.get("/")).status(), is(INTERNAL_SERVER_ERROR));
+            assertThat("the timeout must cancel the response, otherwise a missing interrupt is indistinguishable "
+                    + "from a late one", cancelObserved.await(AWAIT_S, SECONDS), is(true));
+
+            release.countDown();
+            assertThat("the handler must finish even though the exchange is already over",
+                    handlerFinished.await(AWAIT_S, SECONDS), is(true));
+            assertThat("the filter must decide whether the handler thread is interrupted", interrupted.get(),
+                    is(!disableInterrupt));
+        } finally {
+            release.countDown();
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] disableInterrupt={0}")
+    @ValueSource(booleans = {false, true})
+    void timeoutBeforeStreamingResponseMetaData(boolean disableInterrupt) throws Exception {
+        CountDownLatch cancelObserved = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch handlerFinished = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicBoolean writeFailed = new AtomicBoolean();
+
+        BlockingStreamingHttpService service = (ctx, request, response) -> {
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+            if (Thread.interrupted()) {
+                interrupted.set(true);
+            }
+            HttpPayloadWriter<Buffer> writer = response.sendMetaData();
+            try {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii("x"));
+                writer.close();
+            } catch (IOException e) {
+                writeFailed.set(true);
+            } finally {
+                handlerFinished.countDown();
+            }
+        };
+
+        HttpServerBuilder builder = HttpServers.forAddress(localAddress(0))
+                .appendServiceFilter(new TimeoutHttpServiceFilter(TIMEOUT, true))
+                .appendServiceFilter(cancelObserver(cancelObserved));
+        if (disableInterrupt) {
+            builder.appendServiceFilter(DisableInterruptOnCancelHttpServiceFilter.INSTANCE);
+        }
+        ServerContext serverContext = builder.listenBlockingStreamingAndAwait(service);
+        try (BlockingHttpClient client = HttpClients.forSingleAddress(serverHostAndPort(serverContext))
+                .buildBlocking()) {
+            assertThat("the timeout must fire before the handler sends meta-data",
+                    client.request(client.get("/")).status(), is(INTERNAL_SERVER_ERROR));
+            assertThat("the timeout must cancel the response, otherwise a missing interrupt is indistinguishable "
+                    + "from a late one", cancelObserved.await(AWAIT_S, SECONDS), is(true));
+
+            release.countDown();
+            assertThat("the handler must finish even though the exchange is already over",
+                    handlerFinished.await(AWAIT_S, SECONDS), is(true));
+            assertThat("a cancel delivered before sendMetaData() must still terminate the payload writer, otherwise "
+                    + "the handler parks in write() and never releases its offload thread", writeFailed.get(),
+                    is(true));
+            assertThat("the filter must decide whether the handler thread is interrupted", interrupted.get(),
+                    is(!disableInterrupt));
+        } finally {
+            release.countDown();
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] disableInterrupt={0}")
+    @ValueSource(booleans = {false, true})
+    void disconnectDuringStreamingResponse(boolean disableInterrupt) throws Exception {
+        CountDownLatch firstChunkSent = new CountDownLatch(1);
+        CountDownLatch handlerFinished = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicBoolean writeFailed = new AtomicBoolean();
+
+        HttpServerBuilder builder = HttpServers.forAddress(localAddress(0));
+        if (disableInterrupt) {
+            builder.appendServiceFilter(DisableInterruptOnCancelHttpServiceFilter.INSTANCE);
+        }
+        ServerContext serverContext = builder.listenBlockingStreamingAndAwait(
+                chunkingService(firstChunkSent, handlerFinished, interrupted, writeFailed));
+        try {
+            InetSocketAddress serverAddress = (InetSocketAddress) serverContext.listenAddress();
+            try (Socket clientSocket = new Socket(serverAddress.getAddress(), serverAddress.getPort())) {
+                clientSocket.setSoLinger(true, 0);
+                OutputStream out = clientSocket.getOutputStream();
+                out.write(RAW_REQUEST.getBytes(US_ASCII));
+                out.flush();
+                assertThat("the handler never sent its first chunk", firstChunkSent.await(AWAIT_S, SECONDS), is(true));
+            }
+
+            assertThat("the handler must finish regardless of the client having already disconnected",
+                    handlerFinished.await(AWAIT_S, SECONDS), is(true));
+            assertThat("a write against the abandoned connection must fail whatever the filter decides",
+                    writeFailed.get(), is(true));
+            assertThat("the filter must decide whether the handler thread is interrupted", interrupted.get(),
+                    is(!disableInterrupt));
+        } finally {
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] disableInterrupt={0}")
+    @ValueSource(booleans = {false, true})
+    void nonGracefulServerCloseDuringStreamingResponse(boolean disableInterrupt) throws Exception {
+        CountDownLatch firstChunkSent = new CountDownLatch(1);
+        CountDownLatch handlerFinished = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AtomicBoolean writeFailed = new AtomicBoolean();
+
+        HttpServerBuilder builder = HttpServers.forAddress(localAddress(0));
+        if (disableInterrupt) {
+            builder.appendServiceFilter(DisableInterruptOnCancelHttpServiceFilter.INSTANCE);
+        }
+        ServerContext serverContext = builder.listenBlockingStreamingAndAwait(
+                chunkingService(firstChunkSent, handlerFinished, interrupted, writeFailed));
+        try {
+            InetSocketAddress serverAddress = (InetSocketAddress) serverContext.listenAddress();
+            try (Socket clientSocket = new Socket(serverAddress.getAddress(), serverAddress.getPort())) {
+                OutputStream out = clientSocket.getOutputStream();
+                out.write(RAW_REQUEST.getBytes(US_ASCII));
+                out.flush();
+                assertThat("the handler never sent its first chunk", firstChunkSent.await(AWAIT_S, SECONDS),
+                        is(true));
+
+                // A non-graceful close kills in-flight connections. Do not wait for it here: it cannot complete
+                // until the handler below returns.
+                serverContext.closeAsync().subscribe();
+
+                assertThat("the handler must finish even though the server is already closing",
+                        handlerFinished.await(AWAIT_S, SECONDS), is(true));
+                assertThat("a write against the killed connection must fail whatever the filter decides",
+                        writeFailed.get(), is(true));
+                assertThat("the filter must decide whether the handler thread is interrupted", interrupted.get(),
+                        is(!disableInterrupt));
+            }
+        } finally {
+            serverContext.closeAsync().toFuture().get();
+        }
+    }
+
+    /**
+     * Streams a first chunk to prove the response is under way, then alternates unrelated blocking work with further
+     * writes until a write fails. The blocking work is deliberately not an I/O call, so an interrupt observed there
+     * cannot be confused with the write failing.
+     */
+    private static BlockingStreamingHttpService chunkingService(final CountDownLatch firstChunkSent,
+                                                               final CountDownLatch handlerFinished,
+                                                               final AtomicBoolean interrupted,
+                                                               final AtomicBoolean writeFailed) {
+        return (ctx, request, response) -> {
+            HttpPayloadWriter<Buffer> writer = response.sendMetaData();
+            try {
+                writer.write(ctx.executionContext().bufferAllocator().fromAscii("first"));
+                writer.flush();
+                firstChunkSent.countDown();
+                int chunksAfterFailure = 0;
+                for (int i = 0; i < MAX_CHUNKS && chunksAfterFailure < CHUNKS_AFTER_FAILURE; i++) {
+                    if (sleepWasInterrupted(CHUNK_GAP_MILLIS) || Thread.interrupted()) {
+                        interrupted.set(true);
+                    }
+                    try {
+                        writer.write(ctx.executionContext().bufferAllocator().fromAscii("x"));
+                        writer.flush();
+                    } catch (IOException e) {
+                        writeFailed.set(true);
+                    }
+                    if (writeFailed.get()) {
+                        chunksAfterFailure++;
+                    }
+                }
+                writer.close();
+            } catch (IOException e) {
+                writeFailed.set(true);
+            } finally {
+                handlerFinished.countDown();
+            }
+        };
+    }
+
+    private static StreamingHttpServiceFilterFactory cancelObserver(final CountDownLatch cancelObserved) {
+        return delegate -> new StreamingHttpServiceFilter(delegate) {
+            @Override
+            public Single<StreamingHttpResponse> handle(final HttpServiceContext ctx,
+                                                        final StreamingHttpRequest request,
+                                                        final StreamingHttpResponseFactory responseFactory) {
+                return delegate().handle(ctx, request, responseFactory).afterCancel(cancelObserved::countDown);
+            }
+        };
+    }
+
+    private static boolean sleepWasInterrupted(final long millis) {
+        try {
+            Thread.sleep(millis);
+            return false;
+        } catch (InterruptedException e) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
#### Motivation

When a response is cancelled — a client disconnect, a timeout, or a gRPC
deadline — ServiceTalk interrupts the thread running a `listenBlocking` or
`listenBlockingStreaming` service, and there is no way to opt out. That interrupt
can land in blocking work unrelated to the cancelled exchange, and the usual
`catch (InterruptedException e) { restore; rethrow; }` idiom relays it into every
later blocking call on that thread.

The interrupt is also redundant: a `BlockingStreamingHttpService` already learns
the peer is gone when its next `HttpPayloadWriter#write` throws `IOException`.
Only the interrupt needs to go, and the cancel must keep propagating so that
signal survives — which is why a service filter alone cannot do this.

#### Modifications

- Add `DisableInterruptOnCancelHttpServiceFilter`, a singleton service filter. It
  is the only public addition; the request-context key it sets is
  package-private.
- Honor that key in the blocking and blocking-streaming service adapters.

#### Result

Append `DisableInterruptOnCancelHttpServiceFilter.INSTANCE` ahead of a blocking
service and its thread is no longer interrupted when the response is cancelled.
This covers routers and gRPC services, which build on the same adapters.

Cancellation stays observable: a `BlockingStreamingHttpService` still sees `write`
fail. An aggregated `BlockingHttpService` has no such signal and runs to
completion, so nothing releases a thread that blocks indefinitely.

The default is unchanged, and the key is read only by the blocking adapters, so
`listenStreaming` and asynchronous services are unaffected. No API compatibility
impact.