### PR TITLE
docs: java.net.preferIPv6Stack -> java.net.preferIPv6Addresses

### DIFF
--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsResolverAddressTypes.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsResolverAddressTypes.java
@@ -58,7 +58,7 @@ public enum DnsResolverAddressTypes {
 
     /**
      * The default value, based on "java.net" system properties: {@code java.net.preferIPv4Stack} and
-     * {@code java.net.preferIPv6Stack}.
+     * {@code java.net.preferIPv6Addresses}.
      *
      * @return the system default value.
      */

--- a/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
+++ b/servicetalk-dns-discovery-netty/src/main/java/io/servicetalk/dns/discovery/netty/DnsServiceDiscovererBuilder.java
@@ -227,7 +227,7 @@ public interface DnsServiceDiscovererBuilder {
      * Sets the list of the protocol families of the address resolved.
      *
      * @param dnsResolverAddressTypes the address types or {@code null} to use the default value, based on "java.net"
-     * system properties: {@code java.net.preferIPv4Stack} and {@code java.net.preferIPv6Stack}.
+     * system properties: {@code java.net.preferIPv4Stack} and {@code java.net.preferIPv6Addresses}.
      * @return {@code this}.
      */
     DnsServiceDiscovererBuilder dnsResolverAddressTypes(


### PR DESCRIPTION
There is no `java.net.preferIPv6Stack` system property in java. It should be `java.net.preferIPv6Addresses` instead