### PR TITLE
concurrent-internal: fix ThreadInterruptingCancellable interrupt leak

### DIFF
--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
@@ -98,7 +98,7 @@ public final class ThreadInterruptingCancellable implements Cancellable {
         while (thread.get() == INTERRUPTING) {
             Thread.yield();
         }
-        if (thread.get() == INTERRUPTED) {
+        if (thread.compareAndSet(INTERRUPTED, DONE)) {
             interrupted();
         }
     }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
@@ -17,8 +17,7 @@ package io.servicetalk.concurrent.internal;
 
 import io.servicetalk.concurrent.Cancellable;
 
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.lang.Thread.interrupted;
 import static java.util.Objects.requireNonNull;
@@ -30,62 +29,33 @@ import static java.util.Objects.requireNonNull;
  * thread after the associated blocking operation completes to avoid "spurious" thread interrupts.
  */
 public final class ThreadInterruptingCancellable implements Cancellable {
-    private static final AtomicReferenceFieldUpdater<ThreadInterruptingCancellable, Object> threadUpdater =
-            AtomicReferenceFieldUpdater.newUpdater(ThreadInterruptingCancellable.class, Object.class, "thread");
-    private static final Object CANCELLED = new Object();
-    // cancel() moves a live Thread through INTERRUPTING (interrupt() in progress) to INTERRUPTED so a concurrent
+    // cancel() moves the live Thread through INTERRUPTING (interrupt() in progress) to INTERRUPTED so a concurrent
     // setDone() can wait for the interrupt to actually fire before clearing it.
     private static final Object INTERRUPTING = new Object();
     private static final Object INTERRUPTED = new Object();
     private static final Object DONE = new Object();
-    @Nullable
-    private volatile Object thread;
+
+    // final field: safely published, so the bound thread is visible even under unsafe publication.
+    private final AtomicReference<Object> thread;
 
     /**
      * Create a new instance.
      * @param threadToInterrupt The thread {@link Thread#interrupt() interrupt} in {@link #cancel()}.
      */
     public ThreadInterruptingCancellable(Thread threadToInterrupt) {
-        // thread is not final, so it is possible for the constructor to exit and this object to be used before
-        // thread state is initialized. To make this code safe we atomically set only if null.
-        // https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.5
-        if (!threadUpdater.compareAndSet(this, null, requireNonNull(threadToInterrupt))) {
-            handleInitFail(threadToInterrupt);
-        }
-    }
-
-    private void handleInitFail(Thread threadToInterrupt) {
-        if (threadUpdater.compareAndSet(this, CANCELLED, INTERRUPTING)) {
-            try {
-                threadToInterrupt.interrupt();
-            } finally {
-                thread = INTERRUPTED;
-            }
-        }
+        thread = new AtomicReference<>(requireNonNull(threadToInterrupt));
     }
 
     @Override
     public void cancel() {
-        for (;;) {
-            final Object current = thread;
-            if (current instanceof Thread) {
-                // Move through INTERRUPTING so a concurrent setDone() waits for interrupt() to fire before clearing it.
-                if (threadUpdater.compareAndSet(this, current, INTERRUPTING)) {
-                    try {
-                        ((Thread) current).interrupt();
-                    } finally {
-                        thread = INTERRUPTED;
-                    }
-                    return;
-                }
-            } else if (current == null) {
-                // Raced ahead of the constructor; leave CANCELLED for it to honor.
-                if (threadUpdater.compareAndSet(this, null, CANCELLED)) {
-                    return;
-                }
-            } else {
-                // Already CANCELLED, INTERRUPTING, INTERRUPTED, or DONE: nothing to do.
-                return;
+        final Object current = thread.get();
+        // If current is not a Thread the state is already INTERRUPTING/INTERRUPTED/DONE; if the CAS loses, a concurrent
+        // cancel()/setDone() won and there is nothing left to do. Either way cancel() is a NOOP.
+        if (current instanceof Thread && thread.compareAndSet(current, INTERRUPTING)) {
+            try {
+                ((Thread) current).interrupt();
+            } finally {
+                thread.set(INTERRUPTED);
             }
         }
     }
@@ -95,8 +65,8 @@ public final class ThreadInterruptingCancellable implements Cancellable {
      * should be NOOPs.
      */
     public void setDone() {
-        final Object currThread = thread;
-        if (currThread instanceof Thread && threadUpdater.compareAndSet(this, currThread, DONE)) {
+        final Object current = thread.get();
+        if (current instanceof Thread && thread.compareAndSet(current, DONE)) {
             return;
         }
         clearRacingInterrupt();
@@ -111,8 +81,8 @@ public final class ThreadInterruptingCancellable implements Cancellable {
      * the interrupt status.
      */
     public void setDone(Throwable cause) {
-        final Object currThread = thread;
-        if (currThread instanceof Thread && threadUpdater.compareAndSet(this, currThread, DONE)) {
+        final Object current = thread.get();
+        if (current instanceof Thread && thread.compareAndSet(current, DONE)) {
             if (cause instanceof InterruptedException) {
                 interrupted();
             }
@@ -125,10 +95,10 @@ public final class ThreadInterruptingCancellable implements Cancellable {
         // A concurrent cancel() delivered (or is delivering) an interrupt. Busy-wait until interrupt() has been called
         // (INTERRUPTED) so it is captured, then clear it to avoid a spurious interrupt on this (bound) thread. A DONE
         // state means a prior setDone() already handled completion, so there is no cancel interrupt to clear.
-        while (thread == INTERRUPTING) {
+        while (thread.get() == INTERRUPTING) {
             Thread.yield();
         }
-        if (thread == INTERRUPTED) {
+        if (thread.get() == INTERRUPTED) {
             interrupted();
         }
     }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Apple Inc. and the ServiceTalk project authors
+ * Copyright © 2018, 2026 Apple Inc. and the ServiceTalk project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,17 @@ import static java.util.Objects.requireNonNull;
 /**
  * A {@link Cancellable} that will {@link Thread#interrupt() interrupt a thread}.
  * <p>
- * It is important that {@link #setDone()} (or {@link #setDone(Throwable)}) is called after the associated blocking
- * operation completes to avoid "spurious" thread interrupts.
+ * It is important that {@link #setDone()} (or {@link #setDone(Throwable)}) is called on the interrupted
+ * thread after the associated blocking operation completes to avoid "spurious" thread interrupts.
  */
-public class ThreadInterruptingCancellable implements Cancellable {
+public final class ThreadInterruptingCancellable implements Cancellable {
     private static final AtomicReferenceFieldUpdater<ThreadInterruptingCancellable, Object> threadUpdater =
             AtomicReferenceFieldUpdater.newUpdater(ThreadInterruptingCancellable.class, Object.class, "thread");
     private static final Object CANCELLED = new Object();
+    // cancel() moves a live Thread through INTERRUPTING (interrupt() in progress) to INTERRUPTED so a concurrent
+    // setDone() can wait for the interrupt to actually fire before clearing it.
+    private static final Object INTERRUPTING = new Object();
+    private static final Object INTERRUPTED = new Object();
     private static final Object DONE = new Object();
     @Nullable
     private volatile Object thread;
@@ -51,27 +55,39 @@ public class ThreadInterruptingCancellable implements Cancellable {
     }
 
     private void handleInitFail(Thread threadToInterrupt) {
-        if (thread == CANCELLED) {
-            threadToInterrupt.interrupt();
+        if (threadUpdater.compareAndSet(this, CANCELLED, INTERRUPTING)) {
+            try {
+                threadToInterrupt.interrupt();
+            } finally {
+                thread = INTERRUPTED;
+            }
         }
     }
 
     @Override
     public void cancel() {
-        final Object currThread = threadUpdater.getAndAccumulate(this, CANCELLED,
-                (prev, x) -> prev == DONE ? DONE : CANCELLED);
-        if (currThread instanceof Thread) {
-            beforeInterrupt();
-            ((Thread) currThread).interrupt();
+        for (;;) {
+            final Object current = thread;
+            if (current instanceof Thread) {
+                // Move through INTERRUPTING so a concurrent setDone() waits for interrupt() to fire before clearing it.
+                if (threadUpdater.compareAndSet(this, current, INTERRUPTING)) {
+                    try {
+                        ((Thread) current).interrupt();
+                    } finally {
+                        thread = INTERRUPTED;
+                    }
+                    return;
+                }
+            } else if (current == null) {
+                // Raced ahead of the constructor; leave CANCELLED for it to honor.
+                if (threadUpdater.compareAndSet(this, null, CANCELLED)) {
+                    return;
+                }
+            } else {
+                // Already CANCELLED, INTERRUPTING, INTERRUPTED, or DONE: nothing to do.
+                return;
+            }
         }
-    }
-
-    /**
-     * Test checkpoint invoked in {@link #cancel()} after the bound thread has been observed but before it is
-     * {@link Thread#interrupt() interrupted}. Overridable so tests can deterministically interpose completion into the
-     * interrupt window and reproduce the leaked-interrupt race.
-     */
-    void beforeInterrupt() {
     }
 
     /**
@@ -79,7 +95,11 @@ public class ThreadInterruptingCancellable implements Cancellable {
      * should be NOOPs.
      */
     public void setDone() {
-        thread = DONE;
+        final Object currThread = thread;
+        if (currThread instanceof Thread && threadUpdater.compareAndSet(this, currThread, DONE)) {
+            return;
+        }
+        clearRacingInterrupt();
     }
 
     /**
@@ -91,8 +111,24 @@ public class ThreadInterruptingCancellable implements Cancellable {
      * the interrupt status.
      */
     public void setDone(Throwable cause) {
-        setDone();
-        if (cause instanceof InterruptedException) {
+        final Object currThread = thread;
+        if (currThread instanceof Thread && threadUpdater.compareAndSet(this, currThread, DONE)) {
+            if (cause instanceof InterruptedException) {
+                interrupted();
+            }
+            return;
+        }
+        clearRacingInterrupt();
+    }
+
+    private void clearRacingInterrupt() {
+        // A concurrent cancel() delivered (or is delivering) an interrupt. Busy-wait until interrupt() has been called
+        // (INTERRUPTED) so it is captured, then clear it to avoid a spurious interrupt on this (bound) thread. A DONE
+        // state means a prior setDone() already handled completion, so there is no cancel interrupt to clear.
+        while (thread == INTERRUPTING) {
+            Thread.yield();
+        }
+        if (thread == INTERRUPTED) {
             interrupted();
         }
     }

--- a/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
+++ b/servicetalk-concurrent-internal/src/main/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellable.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
  * It is important that {@link #setDone()} (or {@link #setDone(Throwable)}) is called after the associated blocking
  * operation completes to avoid "spurious" thread interrupts.
  */
-public final class ThreadInterruptingCancellable implements Cancellable {
+public class ThreadInterruptingCancellable implements Cancellable {
     private static final AtomicReferenceFieldUpdater<ThreadInterruptingCancellable, Object> threadUpdater =
             AtomicReferenceFieldUpdater.newUpdater(ThreadInterruptingCancellable.class, Object.class, "thread");
     private static final Object CANCELLED = new Object();
@@ -61,8 +61,17 @@ public final class ThreadInterruptingCancellable implements Cancellable {
         final Object currThread = threadUpdater.getAndAccumulate(this, CANCELLED,
                 (prev, x) -> prev == DONE ? DONE : CANCELLED);
         if (currThread instanceof Thread) {
+            beforeInterrupt();
             ((Thread) currThread).interrupt();
         }
+    }
+
+    /**
+     * Test checkpoint invoked in {@link #cancel()} after the bound thread has been observed but before it is
+     * {@link Thread#interrupt() interrupted}. Overridable so tests can deterministically interpose completion into the
+     * interrupt window and reproduce the leaked-interrupt race.
+     */
+    void beforeInterrupt() {
     }
 
     /**

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellableTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellableTest.java
@@ -17,14 +17,12 @@ package io.servicetalk.concurrent.internal;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -37,107 +35,81 @@ class ThreadInterruptingCancellableTest {
     }
 
     @Test
-    void cancelRacingWithSuccessfulCompletionLeaksNoInterrupt() throws Exception {
+    void cancelBeforeSetDoneClearsInterrupt() {
         final Thread boundThread = Thread.currentThread();
-        final CountDownLatch atCheckpoint = new CountDownLatch(1);
-        final CountDownLatch completionDone = new CountDownLatch(1);
+        final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(boundThread);
 
-        // The checkpoint forces cancel() to observe the bound thread, then pause until the operation has already
-        // completed via setDone(), so the interrupt is delivered strictly inside the completion window.
-        final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(boundThread) {
-            @Override
-            void beforeInterrupt() {
-                atCheckpoint.countDown();
-                try {
-                    completionDone.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-        };
+        cancellable.cancel();
+        assertThat("cancel() did not interrupt the bound thread", boundThread.isInterrupted(), is(true));
 
-        final Thread canceller = new Thread(cancellable::cancel);
-        canceller.start();
-
-        atCheckpoint.await();
         cancellable.setDone();
-        completionDone.countDown();
-
-        // The interrupt lands on this (bound) thread; spin rather than join() so an interruptible wait does not
-        // consume the very flag under test.
-        while (canceller.isAlive()) {
-            Thread.yield();
-        }
-
-        assertThat("cancel() leaked an interrupt after successful completion",
+        assertThat("setDone() did not clear the interrupt delivered by cancel()",
                 boundThread.isInterrupted(), is(false));
     }
 
     @Test
-    void cancelLeaksInterruptOntoNextPooledTask() throws Exception {
-        // A single-threaded pool stands in for a ServiceTalk offload pool: tasks run FIFO on one reused thread.
-        // cancel() claims the interrupt but stalls (via the checkpoint) until after the operation completes and the
-        // pool thread has picked up an unrelated follow-up task; the late interrupt() then lands on that task.
-        final ExecutorService pool = Executors.newSingleThreadExecutor();
-        try {
-            final AtomicReference<ThreadInterruptingCancellable> ref = new AtomicReference<>();
-            final CountDownLatch ticReady = new CountDownLatch(1);
-            final CountDownLatch atCheckpoint = new CountDownLatch(1);
-            final CountDownLatch releaseInterrupt = new CountDownLatch(1);
-            final CountDownLatch nextTaskRunning = new CountDownLatch(1);
-            final CountDownLatch nextTaskDone = new CountDownLatch(1);
-            final CountDownLatch neverSignaled = new CountDownLatch(1);
-            final AtomicBoolean nextTaskInterrupted = new AtomicBoolean();
+    void cancelBeforeSetDoneWithCauseClearsInterrupt() {
+        final Thread boundThread = Thread.currentThread();
+        final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(boundThread);
 
-            // The cancelled operation, running on the pool thread.
-            pool.execute(() -> {
-                final ThreadInterruptingCancellable tic =
-                        new ThreadInterruptingCancellable(Thread.currentThread()) {
-                            @Override
-                            void beforeInterrupt() {
-                                atCheckpoint.countDown();
-                                await(releaseInterrupt);
-                            }
-                        };
-                ref.set(tic);
-                ticReady.countDown();
-                await(atCheckpoint);   // cancel() has claimed the bound thread and is stalled before interrupt()
-                tic.setDone();         // operation completes normally
-            });
-
-            // The next, unrelated task on the same pool thread.
-            pool.execute(() -> {
-                nextTaskRunning.countDown();
-                try {
-                    neverSignaled.await(10, SECONDS);
-                } catch (InterruptedException e) {
-                    nextTaskInterrupted.set(true);
-                }
-                nextTaskDone.countDown();
-            });
-
-            ticReady.await();
-            final Thread canceller = new Thread(() -> ref.get().cancel());
-            canceller.start();
-
-            nextTaskRunning.await();       // the follow-up task now owns the pool thread
-            releaseInterrupt.countDown();  // let the stalled cancel() deliver its interrupt
-            canceller.join();
-            nextTaskDone.await();
-
-            assertThat("cancel() leaked an interrupt onto an unrelated pooled task",
-                    nextTaskInterrupted.get(), is(false));
-        } finally {
-            pool.shutdownNow();
-        }
+        cancellable.cancel();
+        cancellable.setDone(new IllegalStateException());
+        assertThat(boundThread.isInterrupted(), is(false));
     }
 
-    private static void await(CountDownLatch latch) {
-        try {
-            latch.await();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException(e);
+    @Test
+    void setDoneLatchesOutLaterCancel() {
+        final Thread boundThread = Thread.currentThread();
+        final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(boundThread);
+
+        cancellable.setDone();
+        cancellable.cancel();
+        assertThat("cancel() interrupted the bound thread after setDone()", boundThread.isInterrupted(), is(false));
+    }
+
+    @Test
+    void setDoneWithInterruptedExceptionClearsInterrupt() {
+        final Thread boundThread = Thread.currentThread();
+        final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(boundThread);
+
+        boundThread.interrupt();
+        cancellable.setDone(new InterruptedException());
+        assertThat(boundThread.isInterrupted(), is(false));
+    }
+
+    @Test
+    @Timeout(30)
+    void concurrentCancelAndSetDoneNeverLeakInterrupt() throws InterruptedException {
+        for (int i = 0; i < 1000; i++) {
+            final AtomicReference<ThreadInterruptingCancellable> ref = new AtomicReference<>();
+            final CountDownLatch ready = new CountDownLatch(1);
+            final AtomicBoolean go = new AtomicBoolean();
+            final CountDownLatch done = new CountDownLatch(1);
+            final AtomicBoolean leaked = new AtomicBoolean();
+
+            final Thread bound = new Thread(() -> {
+                final ThreadInterruptingCancellable tic =
+                        new ThreadInterruptingCancellable(Thread.currentThread());
+                ref.set(tic);
+                ready.countDown();
+                // Non-interruptible spin so the start barrier can't consume the interrupt under test.
+                while (!go.get()) {
+                    Thread.yield();
+                }
+                tic.setDone();
+                leaked.set(Thread.currentThread().isInterrupted());
+                done.countDown();
+            });
+            bound.start();
+
+            ready.await();
+            go.set(true);
+            ref.get().cancel();   // races setDone() on the bound thread
+            done.await();
+            bound.join();
+
+            assertThat("iteration " + i + ": setDone() left a leaked interrupt after a racing cancel()",
+                    leaked.get(), is(false));
         }
     }
 }

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellableTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellableTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.internal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ThreadInterruptingCancellableTest {
+
+    @AfterEach
+    void clearInterrupt() {
+        // A leaked interrupt would otherwise bleed into the next test sharing this thread.
+        Thread.interrupted();
+    }
+
+    @Test
+    void cancelRacingWithSuccessfulCompletionLeaksNoInterrupt() throws Exception {
+        final Thread boundThread = Thread.currentThread();
+        final CountDownLatch atCheckpoint = new CountDownLatch(1);
+        final CountDownLatch completionDone = new CountDownLatch(1);
+
+        // The checkpoint forces cancel() to observe the bound thread, then pause until the operation has already
+        // completed via setDone(), so the interrupt is delivered strictly inside the completion window.
+        final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(boundThread) {
+            @Override
+            void beforeInterrupt() {
+                atCheckpoint.countDown();
+                try {
+                    completionDone.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+
+        final Thread canceller = new Thread(cancellable::cancel);
+        canceller.start();
+
+        atCheckpoint.await();
+        cancellable.setDone();
+        completionDone.countDown();
+
+        // The interrupt lands on this (bound) thread; spin rather than join() so an interruptible wait does not
+        // consume the very flag under test.
+        while (canceller.isAlive()) {
+            Thread.yield();
+        }
+
+        assertThat("cancel() leaked an interrupt after successful completion",
+                boundThread.isInterrupted(), is(false));
+    }
+
+    @Test
+    void cancelLeaksInterruptOntoNextPooledTask() throws Exception {
+        // A single-threaded pool stands in for a ServiceTalk offload pool: tasks run FIFO on one reused thread.
+        // cancel() claims the interrupt but stalls (via the checkpoint) until after the operation completes and the
+        // pool thread has picked up an unrelated follow-up task; the late interrupt() then lands on that task.
+        final ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            final AtomicReference<ThreadInterruptingCancellable> ref = new AtomicReference<>();
+            final CountDownLatch ticReady = new CountDownLatch(1);
+            final CountDownLatch atCheckpoint = new CountDownLatch(1);
+            final CountDownLatch releaseInterrupt = new CountDownLatch(1);
+            final CountDownLatch nextTaskRunning = new CountDownLatch(1);
+            final CountDownLatch nextTaskDone = new CountDownLatch(1);
+            final CountDownLatch neverSignaled = new CountDownLatch(1);
+            final AtomicBoolean nextTaskInterrupted = new AtomicBoolean();
+
+            // The cancelled operation, running on the pool thread.
+            pool.execute(() -> {
+                final ThreadInterruptingCancellable tic =
+                        new ThreadInterruptingCancellable(Thread.currentThread()) {
+                            @Override
+                            void beforeInterrupt() {
+                                atCheckpoint.countDown();
+                                await(releaseInterrupt);
+                            }
+                        };
+                ref.set(tic);
+                ticReady.countDown();
+                await(atCheckpoint);   // cancel() has claimed the bound thread and is stalled before interrupt()
+                tic.setDone();         // operation completes normally
+            });
+
+            // The next, unrelated task on the same pool thread.
+            pool.execute(() -> {
+                nextTaskRunning.countDown();
+                try {
+                    neverSignaled.await(10, SECONDS);
+                } catch (InterruptedException e) {
+                    nextTaskInterrupted.set(true);
+                }
+                nextTaskDone.countDown();
+            });
+
+            ticReady.await();
+            final Thread canceller = new Thread(() -> ref.get().cancel());
+            canceller.start();
+
+            nextTaskRunning.await();       // the follow-up task now owns the pool thread
+            releaseInterrupt.countDown();  // let the stalled cancel() deliver its interrupt
+            canceller.join();
+            nextTaskDone.await();
+
+            assertThat("cancel() leaked an interrupt onto an unrelated pooled task",
+                    nextTaskInterrupted.get(), is(false));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellableTest.java
+++ b/servicetalk-concurrent-internal/src/test/java/io/servicetalk/concurrent/internal/ThreadInterruptingCancellableTest.java
@@ -112,4 +112,20 @@ class ThreadInterruptingCancellableTest {
                     leaked.get(), is(false));
         }
     }
+
+    @Test
+    void repeatSetDoneAfterCancelPreservesForeignInterrupt() {
+        final Thread boundThread = Thread.currentThread();
+        final ThreadInterruptingCancellable cancellable = new ThreadInterruptingCancellable(boundThread);
+
+        cancellable.cancel();
+        cancellable.setDone();
+        assertThat("setDone() did not clear the interrupt delivered by cancel()",
+                boundThread.isInterrupted(), is(false));
+
+        boundThread.interrupt();
+        cancellable.setDone();
+        assertThat("repeat setDone() swallowed an interrupt this Cancellable did not deliver",
+                Thread.interrupted(), is(true));
+    }
 }


### PR DESCRIPTION
#### Motivation

`cancel()` split its state transition and `Thread.interrupt()` into two steps,
so it could deliver an interrupt after the blocking operation had completed and
`setDone()` had run. The no-arg `setDone()` success path never cleared the
flag, leaking a spurious interrupt onto the (typically pooled) serving thread
where it surfaced as an `InterruptedException` in a later, unrelated task.

#### Modifications

- `cancel()` moves through an intermediate `INTERRUPTING` state, delivers the
  interrupt, then publishes `INTERRUPTED`. A `setDone()` that races a `cancel()`
  busy-waits until `interrupt()` has been called (state reaches `INTERRUPTED`)
  so it is guaranteed to capture the delivered interrupt, then clears it, so
  completion never leaves a spurious interrupt behind. `setDone()` must be
  called on the bound thread (all callers already do).
- `setDone(Throwable)` still clears on `InterruptedException`.

#### Results

A `cancel()` racing successful completion no longer leaves a spurious interrupt
behind. Behavior for the callers (`BlockingStreamingToStreamingService`,
`CallableSingle`, `CallableCompletable`) is otherwise unchanged.