### PR TITLE
ThreadInterruptingCancellable: fix interrupt leak when onSubscribe throws

### DIFF
--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CallableCompletable.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CallableCompletable.java
@@ -38,6 +38,9 @@ final class CallableCompletable extends AbstractSynchronousCompletable {
         try {
             subscriber.onSubscribe(cancellable);
         } catch (Throwable cause) {
+            // The Subscriber may have cancelled before throwing, which interrupts this thread. Complete the
+            // Cancellable so the interrupt is not left behind for unrelated work on this (typically pooled) thread.
+            cancellable.setDone(cause);
             handleExceptionFromOnSubscribe(subscriber, cause);
             return;
         }

--- a/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CallableSingle.java
+++ b/servicetalk-concurrent-api/src/main/java/io/servicetalk/concurrent/api/CallableSingle.java
@@ -38,6 +38,9 @@ final class CallableSingle<T> extends AbstractSynchronousSingle<T> {
         try {
             subscriber.onSubscribe(cancellable);
         } catch (Throwable cause) {
+            // The Subscriber may have cancelled before throwing, which interrupts this thread. Complete the
+            // Cancellable so the interrupt is not left behind for unrelated work on this (typically pooled) thread.
+            cancellable.setDone(cause);
             handleExceptionFromOnSubscribe(subscriber, cause);
             return;
         }

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CallableCompletableTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/completable/CallableCompletableTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2026 Apple Inc. and the ServiceTalk project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.servicetalk.concurrent.api.completable;
+
+import io.servicetalk.concurrent.Cancellable;
+import io.servicetalk.concurrent.CompletableSource;
+import io.servicetalk.concurrent.api.Completable;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
+import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+class CallableCompletableTest {
+
+    @ParameterizedTest(name = "{displayName} [{index}] cancel={0}")
+    @ValueSource(booleans = {false, true})
+    void fromCallableOnSubscribeThrows(boolean cancel) {
+        verifyOnSubscribeThrows(cancel, invoked -> Completable.fromCallable(() -> {
+            invoked.set(true);
+            return null;
+        }));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] cancel={0}")
+    @ValueSource(booleans = {false, true})
+    void fromRunnableOnSubscribeThrows(boolean cancel) {
+        verifyOnSubscribeThrows(cancel, invoked -> Completable.fromRunnable(() -> invoked.set(true)));
+    }
+
+    private static void verifyOnSubscribeThrows(boolean cancel,
+                                                Function<AtomicBoolean, Completable> sourceFactory) {
+        final AtomicBoolean invoked = new AtomicBoolean();
+        final Completable source = sourceFactory.apply(invoked);
+
+        final CompletableSource.Subscriber subscriber = mock(CompletableSource.Subscriber.class);
+        // Cancelling from onSubscribe is legal. Throwing afterwards violates the Reactive Streams spec, but the
+        // interrupt delivered by cancel() must still not be left behind on this (typically pooled) thread.
+        doAnswer(invocation -> {
+            if (cancel) {
+                invocation.<Cancellable>getArgument(0).cancel();
+            }
+            throw DELIBERATE_EXCEPTION;
+        }).when(subscriber).onSubscribe(any());
+
+        try {
+            toSource(source).subscribe(subscriber);
+
+            verify(subscriber).onSubscribe(any());
+            verify(subscriber).onError(DELIBERATE_EXCEPTION);
+            verifyNoMoreInteractions(subscriber);
+            assertThat("source work was invoked even though onSubscribe threw", invoked.get(), is(false));
+            assertThat("a throwing onSubscribe left an interrupt behind", Thread.interrupted(), is(false));
+        } finally {
+            // A leaked interrupt would otherwise bleed into the next test sharing this thread.
+            Thread.interrupted();
+        }
+    }
+}

--- a/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
+++ b/servicetalk-concurrent-api/src/test/java/io/servicetalk/concurrent/api/single/CallableSingleTest.java
@@ -21,6 +21,8 @@ import io.servicetalk.concurrent.api.Single;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -28,9 +30,12 @@ import javax.annotation.Nullable;
 
 import static io.servicetalk.concurrent.api.SourceAdapters.toSource;
 import static io.servicetalk.concurrent.internal.DeliberateException.DELIBERATE_EXCEPTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -120,17 +125,33 @@ class CallableSingleTest {
         latch.await();
     }
 
-    @Test
-    void onSubscribeThrows() {
+    @ParameterizedTest(name = "{displayName} [{index}] cancel={0}")
+    @ValueSource(booleans = {false, true})
+    void onSubscribeThrows(boolean cancel) throws Exception {
         final Single<Integer> source = Single.fromCallable(factory);
 
         @SuppressWarnings("unchecked")
         final SingleSource.Subscriber<Integer> subscriber = mock(SingleSource.Subscriber.class);
-        doThrow(DELIBERATE_EXCEPTION).when(subscriber).onSubscribe(any());
+        // Cancelling from onSubscribe is legal. Throwing afterwards violates the Reactive Streams spec, but the
+        // interrupt delivered by cancel() must still not be left behind on this (typically pooled) thread.
+        doAnswer(invocation -> {
+            if (cancel) {
+                invocation.<Cancellable>getArgument(0).cancel();
+            }
+            throw DELIBERATE_EXCEPTION;
+        }).when(subscriber).onSubscribe(any());
 
-        toSource(source).subscribe(subscriber);
-        verify(subscriber).onSubscribe(any());
-        verify(subscriber).onError(DELIBERATE_EXCEPTION);
-        verifyNoMoreInteractions(subscriber);
+        try {
+            toSource(source).subscribe(subscriber);
+
+            verify(subscriber).onSubscribe(any());
+            verify(subscriber).onError(DELIBERATE_EXCEPTION);
+            verifyNoMoreInteractions(subscriber);
+            verify(factory, never()).call();
+            assertThat("a throwing onSubscribe left an interrupt behind", Thread.interrupted(), is(false));
+        } finally {
+            // A leaked interrupt would otherwise bleed into the next test sharing this thread.
+            Thread.interrupted();
+        }
     }
 }

--- a/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
+++ b/servicetalk-http-api/src/main/java/io/servicetalk/http/api/BlockingStreamingToStreamingService.java
@@ -71,6 +71,10 @@ final class BlockingStreamingToStreamingService extends AbstractServiceAdapterHo
                 try {
                     subscriber.onSubscribe(tiCancellable);
                 } catch (Throwable cause) {
+                    // The Subscriber may have cancelled before throwing, which interrupts this thread. Complete the
+                    // Cancellable so the interrupt is not left behind for unrelated work on this (typically pooled)
+                    // thread.
+                    tiCancellable.setDone(cause);
                     handleExceptionFromOnSubscribe(subscriber, cause);
                     return;
                 }

--- a/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
+++ b/servicetalk-http-api/src/test/java/io/servicetalk/http/api/BlockingStreamingToStreamingServiceTest.java
@@ -72,7 +72,12 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -303,6 +308,37 @@ class BlockingStreamingToStreamingServiceTest {
         cancellable.cancel();
         onErrorLatch.await();
         assertThat(throwableRef.get(), instanceOf(InterruptedException.class));
+    }
+
+    @Test
+    void onSubscribeCancelsThenThrowsDoesNotLeakInterrupt() {
+        // handle() is never invoked because onSubscribe throws, so the allocator stub from setup() is never consumed.
+        lenient().when(mockExecutionCtx.bufferAllocator()).thenReturn(DEFAULT_ALLOCATOR);
+        AtomicBoolean handleCalled = new AtomicBoolean();
+        BlockingStreamingHttpService syncService = (ctx, request, response) -> handleCalled.set(true);
+        StreamingHttpService asyncService = toStreamingHttpService(offloadNone(), syncService);
+
+        @SuppressWarnings("unchecked")
+        final SingleSource.Subscriber<StreamingHttpResponse> subscriber = mock(SingleSource.Subscriber.class);
+        // Cancelling from onSubscribe is legal. Throwing afterwards violates the Reactive Streams spec, but the
+        // interrupt delivered by cancel() must still not be left behind on this (typically pooled) thread.
+        doAnswer(invocation -> {
+            invocation.<Cancellable>getArgument(0).cancel();
+            throw DELIBERATE_EXCEPTION;
+        }).when(subscriber).onSubscribe(any());
+
+        try {
+            toSource(asyncService.handle(mockCtx, reqRespFactory.get("/"), reqRespFactory)).subscribe(subscriber);
+
+            verify(subscriber).onSubscribe(any());
+            verify(subscriber).onError(DELIBERATE_EXCEPTION);
+            verifyNoMoreInteractions(subscriber);
+            assertThat("handle() should not be invoked when onSubscribe throws", handleCalled.get(), is(false));
+            assertThat("cancel() from a throwing onSubscribe leaked an interrupt", Thread.interrupted(), is(false));
+        } finally {
+            // A leaked interrupt would otherwise bleed into the next test sharing this thread.
+            Thread.interrupted();
+        }
     }
 
     @Test


### PR DESCRIPTION
#### Motivation

All three `ThreadInterruptingCancellable` call sites return early when `Subscriber#onSubscribe` throws, without calling `setDone()`. A `Subscriber` may legally `cancel()` from inside `onSubscribe` interrupting the subscribing thread and then throw, which is why the `catch` exists. Same class of leak as #3637.

#### Modifications

- `CallableSingle`, `CallableCompletable` and `BlockingStreamingToStreamingService` call `setDone(cause)` before `handleExceptionFromOnSubscribe(...)`, so the interrupt is cleared prior to the terminal signal — matching the other failure paths.
- Added tests to reproduce described behavior.

#### Result

Cancelling then throwing from `onSubscribe` no longer leaves a spurious interrupt behind.